### PR TITLE
gt-blas: mkl support for host blas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,11 +421,14 @@ if (GTENSOR_ENABLE_BLAS)
   elseif (${GTENSOR_DEVICE} STREQUAL "host")
     # only openblas is supported at this time -- needs
     # adaptations for the various cblas interfaces
-    set(BLA_VENDOR OpenBLAS)
     find_package(BLAS REQUIRED)
-    get_filename_component(BLAS_DIR ${BLAS_LIBRARIES} DIRECTORY)
+    if (${BLA_VENDOR} MATCHES "Intel*")
+      target_compile_definitions(gtblas INTERFACE GTENSOR_HOST_BLAS_MKL)
+      find_path(BLAS_INCLUDE_DIRS "mkl_blas.h" PATH ${MKLROOT})
+    else()
+      find_path(BLAS_INCLUDE_DIRS "cblas.h" PATH_SUFFIXES openblas)
+    endif()
     # Hack, see https://gitlab.kitware.com/cmake/cmake/-/issues/20268
-    find_path(BLAS_INCLUDE_DIRS cblas.h PATH_SUFFIXES openblas REQUIRED)
     target_include_directories(BLAS::BLAS INTERFACE ${BLAS_INCLUDE_DIRS})
     find_package(LAPACK REQUIRED)
     target_link_libraries(gtblas INTERFACE BLAS::BLAS LAPACK::LAPACK)

--- a/include/gt-blas/blas.h
+++ b/include/gt-blas/blas.h
@@ -109,6 +109,8 @@ inline typename C::value_type dot(handle_t& h, const C& x, const C& y)
              gt::raw_pointer_cast(y.data()), 1);
 }
 
+#ifdef GTENSOR_HOST_BLAS_MKL
+
 template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
                                                   has_space_type_device_v<C>>>
 inline typename C::value_type dotu(handle_t& h, const C& x, const C& y)
@@ -124,6 +126,8 @@ inline typename C::value_type dotc(handle_t& h, const C& x, const C& y)
   return dotc(h, x.size(), gt::raw_pointer_cast(x.data()), 1,
               gt::raw_pointer_cast(y.data()), 1);
 }
+
+#endif
 
 template <typename M, typename V,
           typename = std::enable_if_t<

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -212,6 +212,8 @@ CREATE_C_DOT(gtblas_ddot, double)
 
 #undef CREATE_C_DOT
 
+#ifndef GTENSOR_HOST_BLAS_MKL
+
 // ======================================================================
 // gtblas_Xdotu
 
@@ -241,6 +243,8 @@ CREATE_C_DOTC(gtblas_cdotc, f2c_complex<float>)
 CREATE_C_DOTC(gtblas_zdotc, f2c_complex<double>)
 
 #undef CREATE_C_DOTC
+
+#endif
 
 // ======================================================================
 // gtblas_Xgemv

--- a/tests/test_blas.cxx
+++ b/tests/test_blas.cxx
@@ -242,6 +242,7 @@ TEST(blas, ddot)
   test_dot_real<double>();
 }
 
+#ifndef GTENSOR_HOST_BLAS_MKL
 template <typename R>
 void test_dot_complex()
 {
@@ -281,6 +282,7 @@ TEST(blas, zdot)
 {
   test_dot_complex<double>();
 }
+#endif
 
 template <typename T>
 void test_gemv_real()


### PR DESCRIPTION
Set BLA_VENDOR=Intel10_64lp_seq cmake variable to use. If mkl is not found, try setting MKLROOT (or source setvars.sh from oneapi base directory). Set BLA_VENDOR=OpenBLAS to use openblas.